### PR TITLE
Fix issue including py-pip setuptools

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.completion.enabled": false,
+    "java.debug.settings.enableRunDebugCodeLens": false
+}

--- a/grabdish/inventory-python/Dockerfile
+++ b/grabdish/inventory-python/Dockerfile
@@ -10,10 +10,12 @@ RUN  yum -y install oracle-release-el7 && \
 
 WORKDIR /app
 COPY inventory/requirements.txt .
-RUN  yum install -y python36 && \
-     yum install -y tar && \
-     rm -rf /var/cache/yum && \
-     python3.6 -m pip install -r requirements.txt
+RUN yum install -y tar && \
+    yum install -y python36 \
+    yum install -y python36-oci-sdk && \
+    rm -rf /var/cache/yum && \
+    python3.6 -m pip install -U pip setuptools && \
+    python3.6 -m pip install -r requirements.txt
 
 ADD inventory .
 ADD common .

--- a/grabdish/inventory-python/inventory/requirements.txt
+++ b/grabdish/inventory-python/inventory/requirements.txt
@@ -1,6 +1,6 @@
-Flask_restful
-gunicorn
-cx_Oracle
-simplejson
-oci
-
+###### Requirements without Version Specifiers ######`
+Flask_restful               # req for app.py
+gunicorn                    # req for config.py
+cx_Oracle                   # req for app.py, consumer.py
+simplejson                  # req for app.py, consumer.py
+oci                         # req for vaultsecret.py 


### PR DESCRIPTION
Dockerfile updated with py setuptools
```
python3.6 -m pip install -U pip setuptools && \
```

Test result:
```
Removing intermediate container c08a8e95da5e
 ---> 586b37c956c2
Successfully built 586b37c956c2
Successfully tagged us-ashburn-1.ocir.io/idcci5ks1puo/grabdish/inventory-python:0.1
The push refers to repository [us-ashburn-1.ocir.io/idcci5ks1puo/grabdish/inventory-python]
d708f8265e68: Preparing
48a8792f31fa: Preparing
34dedf66f2a8: Preparing
eaf3c37f8252: Preparing
5d8ca20f1f94: Preparing
e2c3602b3034: Preparing
59759852752f: Preparing
5d8ca20f1f94: Waiting
e2c3602b3034: Waiting
59759852752f: Waiting
48a8792f31fa: Pushed
d708f8265e68: Pushed
eaf3c37f8252: Pushed
59759852752f: Mounted from idcci5ks1puo/grabdish/inventory-nodejs
5d8ca20f1f94: Pushed
34dedf66f2a8: Pushed
e2c3602b3034: Pushed
0.1: digest: sha256:a02f102fcd93757a5061e067cfa72ab7d0a928d3aaa958a760f57347ffd4d29c size: 1783
```

