### PR TITLE
BYO K8s

### DIFF
--- a/grabdish/utils/main-destroy.sh
+++ b/grabdish/utils/main-destroy.sh
@@ -14,6 +14,13 @@ set -e
 sed -i.bak '/grabdish/d' ~/.bashrc
 
 
+# No destroy necessary for Live Labs
+if test "$(state_get RUN_TYPE)" == "3"; then
+  echo "No teardown required for Live Labs"
+  exit
+fi
+
+
 # Run the os-destroy.sh in the background
 if ps -ef | grep "$GRABDISH_HOME/utils/os-destroy.sh" | grep -v grep; then
   echo "$GRABDISH_HOME/utils/os-destroy.sh is already running"
@@ -51,4 +58,11 @@ export TF_VAR_ociRegionIdentifier="$(state_get REGION)"
 export TF_VAR_runName="$(state_get RUN_NAME)"
 export TF_VAR_orderDbName="$(state_get ORDER_DB_NAME)"
 export TF_VAR_inventoryDbName="$(state_get INVENTORY_DB_NAME)"
+terraform init
 terraform destroy -auto-approve
+
+
+# If BYO K8s then delete the msdataworkshop namespace in k8s
+if state_done BYO_K8S; then
+  kubectl delete ns msdataworkshop
+fi

--- a/grabdish/utils/main-setup.sh
+++ b/grabdish/utils/main-setup.sh
@@ -28,6 +28,7 @@ while ! state_done RUN_TYPE; do
     state_set USER_OCID 'NA'
     state_set USER_NAME "LL$(state_get RESERVATION_ID)-USER"
     state_set_done PROVISIONING
+    state_set_done K8S_PROVISIONING
     state_set RUN_NAME "grabdish$(state_get RESERVATION_ID)"
     state_set ORDER_DB_NAME "ORDER$(state_get RESERVATION_ID)"
     state_set INVENTORY_DB_NAME "INVENTORY$(state_get RESERVATION_ID)"

--- a/grabdish/utils/main-setup.sh
+++ b/grabdish/utils/main-setup.sh
@@ -35,6 +35,14 @@ while ! state_done RUN_TYPE; do
     state_set_done ATP_LIMIT_CHECK
   else
     state_set RUN_TYPE "1"
+    # BYO K8s
+    if test ${BYO_K8S:-UNSET} != 'UNSET'; then
+      state_set_done BYO_K8S
+      state_set_done K8S_PROVISIONING
+      state_set OKE_OCID 'NA'
+      state_set_done KUBECTL
+      state_set_done OKE_LIMIT_CHECK
+    fi
   fi
 done
 
@@ -111,7 +119,7 @@ while ! state_done COMPARTMENT_OCID; do
     COMPARTMENT_OCID=`oci iam compartment create --compartment-id "$(state_get TENANCY_OCID)" --name "$(state_get RUN_NAME)" --description "GrabDish Workshop" --query 'data.id' --raw-output`
     export OCI_CLI_PROFILE=$(state_get REGION)
   else
-    read -p "Please enter your OCI compartments's OCID: " COMPARTMENT_OCID
+    read -p "Please enter your OCI compartment's OCID: " COMPARTMENT_OCID
   fi
   while ! test `oci iam compartment get --compartment-id "$COMPARTMENT_OCID" --query 'data."lifecycle-state"' --raw-output 2>/dev/null`"" == 'ACTIVE'; do
     echo "Waiting for the compartment to become ACTIVE"
@@ -411,14 +419,7 @@ while ! state_done INVENTORY_DB_PASSWORD_SET; do
 done
 
 
-# Wait for OKE Setup
-while ! state_done OKE_SETUP; do
-  # echo "`date`: Waiting for OKE_SETUP"
-  sleep 2
-done
-
-
-# Collect UI password and create secret
+# Create UI password secret
 while ! state_done UI_PASSWORD; do
   while true; do
     if kubectl create -n msdataworkshop -f -; then

--- a/grabdish/utils/oke-setup.sh
+++ b/grabdish/utils/oke-setup.sh
@@ -15,8 +15,8 @@ done
 
 
 # Wait for provisioning
-while ! state_done PROVISIONING; do
-  echo "`date`: Waiting for terraform provisioning"
+while ! state_done K8S_PROVISIONING; do
+  echo "`date`: Waiting for k8s provisioning"
   sleep 10
 done
 
@@ -48,7 +48,7 @@ done
 
 
 # Wait for OKE nodes to become redy
-while true; do
+while ! state_done BYO_K8S; do
   READY_NODES=`kubectl get nodes | grep Ready | wc -l` || echo 'Ignoring any Error'
   if test "$READY_NODES" -ge 3; then
     echo "3 OKE nodes are ready"
@@ -67,13 +67,6 @@ while ! state_done OKE_NAMESPACE; do
     echo "Failed to create namespace.  Retrying..."
     sleep 10
   fi
-done
-
-
-# Wait for Order User (avoid concurrent kubectl)
-while ! state_done ORDER_USER; do
-  echo "`date`: Waiting for ORDER_USER"
-  sleep 2
 done
 
 

--- a/grabdish/utils/terraform.sh
+++ b/grabdish/utils/terraform.sh
@@ -16,15 +16,23 @@ if ! state_done PROVISIONING; then
   export TF_VAR_runName="$(state_get RUN_NAME)"
   export TF_VAR_orderDbName="$(state_get ORDER_DB_NAME)"
   export TF_VAR_inventoryDbName="$(state_get INVENTORY_DB_NAME)"
-   if ! terraform init; then
+
+  if state_done K8S_PROVISIONING; then
+    rm -f containerengine.tf core.tf 
+  fi
+
+  if ! terraform init; then
     echo 'ERROR: terraform init failed!'
     exit
   fi
+
   if ! terraform apply -auto-approve; then
     echo 'ERROR: terraform apply failed!'
     exit
   fi
+  
   cd $GRABDISH_HOME
+  state_set_done K8S_PROVISIONING
   state_set_done PROVISIONING
 fi
 


### PR DESCRIPTION
Add ability to bring you own K8s cluster.  It is assumed that the cluster is up and kubectl has been configured to access it.  For testing, the cluster was created using the OCI Developer Services --> Kubernetes Clusters --> Create Cluster --> Quick Create functionality with default settings (Public Endpoint, Private Workers).  