### PR TITLE
Workaround for bug in v4.43.0 terraform oci provider

### DIFF
--- a/grabdish/terraform/provider.tf
+++ b/grabdish/terraform/provider.tf
@@ -1,3 +1,12 @@
+terraform {  
+  required_providers {
+    oci = {
+      source  = "hashicorp/oci"
+      version = "= 4.42.0"
+    }
+  }
+}
+
 provider "oci" {
   region           = var.ociRegionIdentifier
 }

--- a/grabdish/terraform/provider.tf
+++ b/grabdish/terraform/provider.tf
@@ -1,8 +1,8 @@
-terraform {  
+terraform {
   required_providers {
     oci = {
-      source  = "hashicorp/oci"
-      version = "= 4.42.0"
+      source = "hashicorp/oci"
+      version = "4.42.0"
     }
   }
 }

--- a/grabdish/utils/terraform.sh
+++ b/grabdish/utils/terraform.sh
@@ -21,6 +21,16 @@ if ! state_done PROVISIONING; then
     rm -f containerengine.tf core.tf 
   fi
 
+  cat >~/.terraformrc <<!
+provider_installation {
+  filesystem_mirror {
+    path    = "/usr/share/terraform/providers"
+  }
+  direct {
+  }
+}
+!
+
   if ! terraform init; then
     echo 'ERROR: terraform init failed!'
     exit

--- a/grabdish/utils/terraform.sh
+++ b/grabdish/utils/terraform.sh
@@ -24,7 +24,7 @@ if ! state_done PROVISIONING; then
   cat >~/.terraformrc <<!
 provider_installation {
   filesystem_mirror {
-    path    = "/usr/share/terraform/providers"
+    path    = "/usr/share/terraform/plugins"
   }
   direct {
   }


### PR DESCRIPTION
terraform never completes when provisioning more than one ATP database with provider version v4.43.0.  This is a workaround until the bug gets fixed.