### PR TITLE
Update order-helidon-deployment.yaml

### DIFF
--- a/grabdish/order-helidon/order-helidon-deployment.yaml
+++ b/grabdish/order-helidon/order-helidon-deployment.yaml
@@ -60,3 +60,10 @@ spec:
       - name: creds
         secret:
           secretName: db-wallet-secret
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: order


### PR DESCRIPTION
Force the order-helidon deployment to use a different k8s node for each replica when we scale out.  