### PR TITLE
Remove On Prem Workshop Link and Remove Commands from .bashrc after Teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ microservices complex.
 ## Resources
 
 * [Building Microservices with Oracle Converged Database Workshop][Workshop]
-* [On-Premises: Building Microservices with Oracle Converged Database Workshop][On-Premises-Workshop]
 * [Blogs][Blogs]
 
 
@@ -35,7 +34,5 @@ Licensed under the Universal Permissive License v 1.0 as shown at <https://oss.o
 [Workshops]: https://apexapps.oracle.com/pls/apex/dbpm/r/livelabs/livelabs-workshop-cards?p100_role=12&p100_focus_area=35&me=126
 [DRC]: https://developer.oracle.com
 [Helidon]: https://helidon.io
-[On-Premises-Workshop]: https://github.com/oracle/microservices-datadriven/tree/main/infra
 [Workshop]: https://bit.ly/simplifymicroservices
-[Blogs]: https://blogs.oracle.com/developers/category/dev-app-dev 
-
+[Blogs]: https://blogs.oracle.com/developers/category/dev-app-dev

--- a/workshops/dcms-oci/config/destroy.sh
+++ b/workshops/dcms-oci/config/destroy.sh
@@ -64,6 +64,12 @@ done
 
 rm -f $STATE_FILE
 
+# Remove the source.env from the .bashrc
+PROF=~/.bashrc
+if test -f "$PROF"; then
+  sed -i.bak '/microservices-datadriven/d' $PROF
+fi
+
 # Clean up the auth token
 TOKEN_OCID=$(oci iam auth-token list --region "$(state_get HOME_REGION)" --user-id="$(state_get USER_OCID)" --query 'data[?description=='"'$(state_get DOCKER_AUTH_TOKEN_DESC)'"'].id|[0]' --raw-output)
 oci iam auth-token delete --region "$(state_get HOME_REGION)" --user-id="$(state_get USER_OCID)" --force --auth-token-id "$TOKEN_OCID"


### PR DESCRIPTION
1) Remove On-Prem link from readme
2) Remove commands from .bashrc at the end of teardown