### PR TITLE
PR to address issue 487 - add control to wait for Wallet in Kafka setup

### DIFF
--- a/workshops/txeventq-kafka/cloud-setup/confluent-kafka/kafka-setup.sh
+++ b/workshops/txeventq-kafka/cloud-setup/confluent-kafka/kafka-setup.sh
@@ -14,6 +14,12 @@ while ! state_done DOCKER_COMPOSE; do
   state_set_done DOCKER_COMPOSE
 done
 
+# Wait for Oracle DB Wallet
+while ! state_done CWALLET_SSO_UPDATED; do
+  echo "$(date): Waiting for Oracle DB Wallet provisioning"
+  sleep 10
+done
+
 # Build Confluent Kafka Connect Customer Image
 while ! state_done CFLCONNECT_IMAGE; do
   cd "$LAB_HOME"/cloud-setup/confluent-kafka


### PR DESCRIPTION
This PR fixes issue #487.

Lab 4 failed with Connect Sink and could not find the Oracle Database instance. The DB Wallet was not added to Kafka Connect Custom Image.