### PR TITLE
LB version change, account cleanup

### DIFF
--- a/cloudbank-v2/spring-apps/account/pom.xml
+++ b/cloudbank-v2/spring-apps/account/pom.xml
@@ -21,7 +21,6 @@
 		<narayana-lra.version>5.13.1.Final</narayana-lra.version>
 		<jakarta.enterprise.cdi-api.version>2.0.2</jakarta.enterprise.cdi-api.version>
 		<oracle-springboot-starter.version>2.7.7</oracle-springboot-starter.version>
-		<javax.el.version>3.0.0</javax.el.version>
 		<liquibase.version>4.19.0</liquibase.version>
 	</properties>
 

--- a/cloudbank-v2/spring-apps/customer/pom.xml
+++ b/cloudbank-v2/spring-apps/customer/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <oracle-springboot-starter.version>2.7.7</oracle-springboot-starter.version>
-        <liquibase.version>4.19.1</liquibase.version>
+        <liquibase.version>4.19.0</liquibase.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

Fixed the following error for customer service:
```
2023-06-14 15:21:23.351  WARN 1 --- [           main] liquibase.util                           : Failed to set code point limit for SnakeYaml, because the version of SnakeYaml being used is too old. Consider upgrading to a SnakeYaml version equal to or newer than 1.32, by downloading and installing a newer version of Liquibase (which includes a newer version of SnakeYaml). Loading particularly large JSON and YAML documents (like snapshots) in Liquibase may fail if SnakeYaml is not upgraded.
```

Removed unnecessary version tags for account service