### PR TITLE
Updated k8s version to 1.26.2 in container engine Terraform files

### DIFF
--- a/grabdish/terraform/containerengine.tf
+++ b/grabdish/terraform/containerengine.tf
@@ -7,7 +7,7 @@ resource "oci_containerengine_cluster" "okell_cluster" {
     ]
     subnet_id = oci_core_subnet.endpoint_Subnet.id
   }
-  kubernetes_version = "v1.25.4"
+  kubernetes_version = "v1.26.2"
   name               = "grabdish"
   vcn_id             = oci_core_vcn.okell_vcn.id
   #Optional
@@ -34,7 +34,7 @@ resource "oci_containerengine_node_pool" "okell_node_pool" {
   #Required
   cluster_id         = oci_containerengine_cluster.okell_cluster.id
   compartment_id     = var.ociCompartmentOcid
-  kubernetes_version = "v1.25.4"
+  kubernetes_version = "v1.26.2"
   name               = "Pool"
 #  node_shape="VM.Standard2.4"
 #  node_shape         = "VM.Standard.B2.1"

--- a/infra/k8s/oke/terraform/containerengine.tf
+++ b/infra/k8s/oke/terraform/containerengine.tf
@@ -10,7 +10,7 @@ resource "oci_containerengine_cluster" "oke" {
     ]
     subnet_id = oci_core_subnet.endpoint.id
   }
-  kubernetes_version = "v1.25.4"
+  kubernetes_version = "v1.26.2"
   name               = "grabdish"
   vcn_id             = data.oci_core_vcn.vcn.id
   #Optional
@@ -37,7 +37,7 @@ resource "oci_containerengine_cluster" "oke" {
 resource "oci_containerengine_node_pool" "okell_node_pool" {
   cluster_id         = oci_containerengine_cluster.oke.id
   compartment_id     = var.ociCompartmentOcid
-  kubernetes_version = "v1.25.4"
+  kubernetes_version = "v1.26.2"
   name               = "Pool"
   node_shape         = "VM.Standard.E2.1"
   node_config_details {


### PR DESCRIPTION
Replaces PR https://github.com/oracle/microservices-datadriven/pull/692 which had OCA signing issues.
This fix prevents a SETUP FAILED while running "setup" from the command line while doing the unified observability livelab (OCI finds a mismatch of k8s versions and fails).