### PR TITLE
Updated OCI provider in Terraform provider configuration

### DIFF
--- a/grabdish/terraform/provider.tf
+++ b/grabdish/terraform/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     oci = {
-      source = "hashicorp/oci"
+      source = "oracle/oci"
       version = "4.42.0"
     }
   }

--- a/infra/network/oci/terraform/provider.tf
+++ b/infra/network/oci/terraform/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     oci = {
-      source = "hashicorp/oci"
+      source = "oracle/oci"
       version = "4.42.0"
     }
   }


### PR DESCRIPTION
This fixes a SETUP FAILED in the Grabdish livelab.
`hashicorp/oci` is obsolete, replaaced with `oracle/oci`
Some parts of the project were already up-to-date but these two files were not.