### PR TITLE
Terraform provider revert

### DIFF
--- a/infra/network/oci/terraform/provider.tf
+++ b/infra/network/oci/terraform/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     oci = {
-      source = "oracle/oci"
+      source = "hashicorp/oci"
       version = "4.42.0"
     }
   }


### PR DESCRIPTION
This config file has to be reverted to use hashicorp/oci instead of oracle/oci otherwise setup of the observability livelab fails