### PR TITLE
Fix Grafana get the password command.

### DIFF
--- a/docs-source/spring/content/observability/metrics/_index.md
+++ b/docs-source/spring/content/observability/metrics/_index.md
@@ -276,7 +276,7 @@ Prometheus is an open source monitoring and alerting system. Prometheus collects
     * To get the password, run this command:
 
       ```shell
-      kubectl -n grafana get secret grafana -o jsonpath='{.data.admin-password}' | base64 -d
+      kubectl -n grafana get secret grafana-dashboard-authn -o jsonpath='{.data.password}' | base64 -d
       ```
 
       > **NOTE:** If you do not have `base64`, leave off the last part (`| base64 -d`) in the command, then copy the output, and use this


### PR DESCRIPTION
In OBaaS version 1.1.0 the grafana dashboard secret name is `grafana-dashboard-authn` and the data is `password`.