### PR TITLE
allow custom Java environment variables in OTEL instrumentation

### DIFF
--- a/helm/infra-charts/obaas/templates/observability/opentelemetry-instrumentation.yaml
+++ b/helm/infra-charts/obaas/templates/observability/opentelemetry-instrumentation.yaml
@@ -15,4 +15,9 @@ spec:
     {{- if .Values.signoz.instrumentation.sampler.argument }}
     argument: {{ .Values.signoz.instrumentation.sampler.argument | quote }}
     {{- end }}
+  {{- if .Values.signoz.instrumentation.java.env }}
+  java:
+    env:
+      {{- toYaml .Values.signoz.instrumentation.java.env | nindent 6 }}
+  {{- end }}
 {{- end }}

--- a/helm/infra-charts/obaas/values.yaml
+++ b/helm/infra-charts/obaas/values.yaml
@@ -531,6 +531,13 @@ signoz:
       type: "parentbased_traceidratio"
       # Only applies if using a ratio sampler. 1.0 = 100%, 0.1 = 10%
       argument: "1.0"
+    java:
+      # Custom environment variables for Java instrumentation
+      # Example:
+      # env:
+      #   - name: OTEL_LOGS_EXPORTER
+      #     value: otlp
+      env: []
   
   # Change to override individual component images
   signoz:


### PR DESCRIPTION
**User Guide: Customizing Java Instrumentation**
You can now pass custom environment variables to the OpenTelemetry Java agent via the obaas Helm chart. This allows you to tune logging, protocol settings, and agent behavior without modifying core templates.

**Method 1: Using `values.yaml `(Recommended)**
This is the best way to maintain a persistent configuration across redeployments. Add the env list to your custom values file:

```
yaml
signoz:
  instrumentation:
    java:
      env:
        - name: "OTEL_LOGS_EXPORTER"
          value: "otlp"
        - name: "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
          value: "grpc"
        - name: "CUSTOM_JAVA_SETTING"
          value: "enabled"
```
Then deploy with:

`helm upgrade --install obaas ./helm/infra-charts/obaas -f my-values.yaml`

**Method 2: Using Helm CLI (`--set-json`)**
This is ideal for quick testing or one-off overrides. Using --set-json is much cleaner than standard --set for lists.

```
helm upgrade --install obaas ./helm/infra-charts/obaas \
  --set-json 'signoz.instrumentation.java.env=[{"name":"FS_GIU_TEST_VAR","value":"test_successful"}]'
```

**How to Verify Changes**

**1. Check the Resource**
Verify that the `Instrumentation` custom resource picked up your variables:
`
kubectl get instrumentation traces-instrumentation -n obaas -o yaml`

**2. Check the Application Pods**

> IMPORTANT
> 
> The OTEL Operator only injects variables during pod creation. If your application pods are already running, you must restart them to pick up the new settings: kubectl rollout restart deployment <service-name> -n obaas

Once the new pods are running, verify the environment:
`
kubectl exec <pod-name> -n obaas -- env | grep OTEL_`
