### PR TITLE
Improve transactionality to prevent dirty writes

### DIFF
--- a/cloudbank-v5/account/src/main/java/com/example/accounts/repository/AccountRepository.java
+++ b/cloudbank-v5/account/src/main/java/com/example/accounts/repository/AccountRepository.java
@@ -6,7 +6,9 @@ package com.example.accounts.repository;
 import java.util.List;
 
 import com.example.accounts.model.Account;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
@@ -14,5 +16,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     List<Account> findAccountsByAccountNameContains(String accountName);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Account findByAccountId(long accountId);
 }

--- a/cloudbank-v5/account/src/main/java/com/example/accounts/services/DepositService.java
+++ b/cloudbank-v5/account/src/main/java/com/example/accounts/services/DepositService.java
@@ -13,6 +13,7 @@ import com.oracle.microtx.springboot.lra.annotation.ParticipantStatus;
 import com.oracle.microtx.springboot.lra.annotation.Status;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -38,6 +39,7 @@ public class DepositService {
      */
     @PostMapping
     @LRA(value = LRA.Type.MANDATORY, end = false)
+    @Transactional
     public ResponseEntity<String> deposit(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId,
                             @RequestParam("accountId") long accountId,
                             @RequestParam("amount") long depositAmount) {
@@ -72,9 +74,10 @@ public class DepositService {
     /**
      * Increase balance amount as recorded in journal during deposit call.
      * Update LRA state to ParticipantStatus.Completed.
-     */
+    */
     @PutMapping("/complete")
     @Complete
+    @Transactional
     public ResponseEntity<String> completeWork(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId) throws Exception {
         log.info("deposit complete called for LRA : " + lraId);
     

--- a/cloudbank-v5/account/src/main/java/com/example/accounts/services/WithdrawService.java
+++ b/cloudbank-v5/account/src/main/java/com/example/accounts/services/WithdrawService.java
@@ -13,6 +13,7 @@ import com.oracle.microtx.springboot.lra.annotation.ParticipantStatus;
 import com.oracle.microtx.springboot.lra.annotation.Status;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -38,6 +39,7 @@ public class WithdrawService {
     */
     @PostMapping
     @LRA(value = LRA.Type.MANDATORY, end = false)
+    @Transactional
     public ResponseEntity<String> withdraw(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId,
             @RequestParam("accountId") long accountId,
             @RequestParam("amount") long withdrawAmount) {
@@ -98,6 +100,7 @@ public class WithdrawService {
     */
     @PutMapping("/compensate")
     @Compensate
+    @Transactional
     public ResponseEntity<String> compensateWork(@RequestHeader(LRA_HTTP_CONTEXT_HEADER) String lraId) 
         throws Exception {
         log.info("Account withdraw compensate() called for LRA : " + lraId);


### PR DESCRIPTION
This PR improves the transactionality in the account service to prevent using out of date data when writing updates to the database.
Tested and verified by deploying cloudbank and exercising account and transfer endpoints.