### PR TITLE
enable JSON logging and trace-log correlation with JUL bridge

### DIFF
--- a/cloudbank-v5/helidon-producer/README.md
+++ b/cloudbank-v5/helidon-producer/README.md
@@ -93,3 +93,14 @@ End-to-end trace context propagation showing the REST HTTP request wrapping the 
 Direct visualization of the OpenTelemetry Kafka Producer metrics (e.g., `kafka.producer.request_latency_max`) grouped by `service_name`.
 
 ![Kafka Producer Metric](docs/kafka-producer-metric.png)
+
+## Log-Trace Correlation
+
+This project is configured for full **Log-Trace Correlation** in SigNoz, allowing you to jump from a specific log message directly to the trace that generated it.
+
+### Implementation Details:
+*   **Structured JSON Logging**: The application uses `logback.xml` with the `LogstashEncoder` to output logs as structured JSON instead of plain text.
+*   **JUL-to-SLF4J Bridge**: We use the `jul-to-slf4j` bridge and the `ProducerApplication` class to intercept Helidon's internal `java.util.logging` calls. This ensures that even internal Helidon logs follow our JSON format.
+*   **Automatic Context Injection**: The OpenTelemetry Java Agent automatically injects the active `trace_id` and `span_id` into the Logback Mapped Diagnostic Context (MDC) for every log entry.
+*   **SigNoz Integration**: SigNoz parses these JSON fields and automatically provides a "View Trace" button in the log details view, enabling seamless navigation between your logs and distributed traces.
+

--- a/cloudbank-v5/helidon-producer/README.md
+++ b/cloudbank-v5/helidon-producer/README.md
@@ -68,9 +68,9 @@ docker build -t REGION.ocir.io/tenancy/cloudbank-v5/helidon-producer:5.0-SNAPSHO
 *(Ensure you push the image to your container registry if running on a remote cluster).*
 
 ### 2. Deploy using Helm
-Deploy the service using the published OBaaS sample app chart:
+Deploy the service using the **local** OBaaS sample app chart to ensure the OpenTelemetry injection logic is applied correctly:
 ```bash
-helm upgrade --install helidon-producer obaas/obaas-sample-app \
+helm upgrade --install helidon-producer ../../helm/app-charts/obaas-sample-app \
   -f values.yaml \
   -n obaas
 ```

--- a/cloudbank-v5/helidon-producer/README.md
+++ b/cloudbank-v5/helidon-producer/README.md
@@ -68,9 +68,9 @@ docker build -t REGION.ocir.io/tenancy/cloudbank-v5/helidon-producer:5.0-SNAPSHO
 *(Ensure you push the image to your container registry if running on a remote cluster).*
 
 ### 2. Deploy using Helm
-Deploy the service using the **local** OBaaS sample app chart to ensure the OpenTelemetry injection logic is applied correctly:
+Deploy the service using the published OBaaS sample app chart:
 ```bash
-helm upgrade --install helidon-producer ../../helm/app-charts/obaas-sample-app \
+helm upgrade --install helidon-producer obaas/obaas-sample-app \
   -f values.yaml \
   -n obaas
 ```

--- a/cloudbank-v5/helidon-producer/pom.xml
+++ b/cloudbank-v5/helidon-producer/pom.xml
@@ -33,6 +33,12 @@
         <dependency>
             <groupId>io.helidon.messaging.kafka</groupId>
             <artifactId>helidon-messaging-kafka</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-jdk14</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.helidon.microprofile.openapi</groupId>
@@ -62,6 +68,11 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>7.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>2.0.9</version>
         </dependency>
 
         <dependency>

--- a/cloudbank-v5/helidon-producer/src/main/java/com/example/helidon/producer/ProducerApplication.java
+++ b/cloudbank-v5/helidon-producer/src/main/java/com/example/helidon/producer/ProducerApplication.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+package com.example.helidon.producer;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+/**
+ * Main entry point for the Helidon JAX-RS Application.
+ * Configures the SLF4J logging bridge to ensure JUL logs are routed to Logback.
+ */
+@ApplicationScoped
+@ApplicationPath("/")
+public class ProducerApplication extends Application {
+
+    public void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        // Remove existing JUL handlers
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+
+        // Install the SLF4J Bridge Handler
+        SLF4JBridgeHandler.install();
+
+        System.out.println("Initialized SLF4JBridgeHandler to route Java Util Logging to Logback for Producer.");
+    }
+}

--- a/cloudbank-v5/helidon-producer/src/main/resources/META-INF/microprofile-config.properties
+++ b/cloudbank-v5/helidon-producer/src/main/resources/META-INF/microprofile-config.properties
@@ -16,3 +16,4 @@ mp.messaging.outgoing.to-kafka.value.serializer=org.apache.kafka.common.serializ
 
 # OpenTelemetry Service Name
 otel.service.name=helidon-producer
+java.util.logging.config.file=logging.properties

--- a/cloudbank-v5/helidon-producer/src/main/resources/logback.xml
+++ b/cloudbank-v5/helidon-producer/src/main/resources/logback.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <fieldNames>
-                <timestamp>timestamp</timestamp>
-                <message>message</message>
-                <logger>logger_name</logger>
-                <thread>thread_name</thread>
-                <level>level</level>
-            </fieldNames>
-        </encoder>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
     <root level="INFO">

--- a/cloudbank-v5/helidon-producer/src/main/resources/logging.properties
+++ b/cloudbank-v5/helidon-producer/src/main/resources/logging.properties
@@ -1,0 +1,2 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler
+.level=INFO


### PR DESCRIPTION
**pom.xml:** 
Added critical dependencies for jul-to-slf4j and logstash-logback-encoder. We also added an exclusion for slf4j-jdk14 to prevent the circular logging loop that was causing the application to crash.

**src/main/resources/logback.xml:** 
Replaced the plain-text encoder with the LogstashEncoder. This enables structured JSON logging, which is required for SigNoz to automatically extract trace and span IDs.

**src/main/resources/META-INF/microprofile-config.properties:** 
Added the configuration to point Helidon to our new logging.properties file at startup.

**README.md:** 
Added a new section on Log-Trace Correlation and performance metrics to help users understand the observability features.

**src/main/resources/logging.properties:** 
A new configuration file that tells the JVM to use the SLF4JBridgeHandler for all internal Helidon logs.

**src/main/java/com/example/helidon/producer/ProducerApplication.java:** 
A new JAX-RS Application class that programmatically installs the logging bridge at the very beginning of the application lifecycle.
