### PR TITLE
allow otelCollectorEndpoint override and rev charts to 0.0.14 (2.1.0-…

### DIFF
--- a/helm/infra-charts/CHANGELOG.md
+++ b/helm/infra-charts/CHANGELOG.md
@@ -102,6 +102,9 @@ AppVersion: 2.1.0-build.12
 
 - Add Kafka metrics
 
-# 0.0.14 - TBA
+# 0.0.14 - May 15, 2026
 
 AppVersion: 2.1.0-build.13
+
+- Allow `otelCollectorEndpoint` override in `Instrumentation` resource
+- Update charts to version 0.0.14 and appVersion 2.1.0-build.13

--- a/helm/infra-charts/obaas-prereqs/Chart.yaml
+++ b/helm/infra-charts/obaas-prereqs/Chart.yaml
@@ -11,9 +11,9 @@ maintainers:
     email: obaas_ww@oracle.com
     url: https://oracle.github.io/microservices-backend
 # This is the chart version.
-version: 0.0.13
+version: 0.0.14
 # This is the version number of the application being deployed.
-appVersion: "2.1.0-build.12"
+appVersion: "2.1.0-build.13"
 
 # SubCharts - Cluster-scoped singleton infrastructure
 dependencies:

--- a/helm/infra-charts/obaas/Chart.yaml
+++ b/helm/infra-charts/obaas/Chart.yaml
@@ -11,9 +11,9 @@ maintainers:
     email: obaas_ww@oracle.com
     url: https://oracle.github.io/microservices-backend
 # This is the chart version.
-version: 0.0.13
+version: 0.0.14
 # This is the version number of the application being deployed.
-appVersion: "2.1.0-build.12"
+appVersion: "2.1.0-build.13"
 
 # SubCharts
 # Note: Cluster-singleton prerequisites (oracle-database-operator, external-secrets, metrics-server,

--- a/helm/infra-charts/obaas/templates/observability/opentelemetry-instrumentation.yaml
+++ b/helm/infra-charts/obaas/templates/observability/opentelemetry-instrumentation.yaml
@@ -5,7 +5,7 @@ metadata:
   name: traces-instrumentation
 spec:
   exporter:
-    endpoint: http://{{ include "obaas.signoz.fullname" . }}-otel-collector:4317
+    endpoint: http://{{ .Values.otelCollectorEndpoint | default (printf "%s-otel-collector:4317" (include "obaas.signoz.fullname" .)) }}
   propagators:
     - tracecontext
     - baggage


### PR DESCRIPTION
…build.13)

**Changes:**

I**nstrumentation Resource Update**: Modified `opentelemetry-instrumentation.yaml` to support a new `otelCollectorEndpoint` value. This allows users to point traces to an external or specific collector while maintaining the current dynamic SigNoz collector as the default.

**Version Revision:**
Updated `obaas` and `obaas-prereqs` charts to version `0.0.14`.
Updated `appVersion` to `2.1.0-build.13`.

**Documentation**: Updated `CHANGELOG.md` with version details and a summary of the OTel endpoint override feature.

**Verification Performed:**

`helm lint `passed for both charts.
`helm template `verified for both the default endpoint rendering and custom endpoint overrides.