### PR TITLE
separate otmm components

### DIFF
--- a/docs-source/site/docs/platform/otmm.md
+++ b/docs-source/site/docs/platform/otmm.md
@@ -39,6 +39,28 @@ lra:
     url: ${MP_LRA_COORDINATOR_URL}
 ```
 
+## Components and enablement
+
+The MicroTx installation is made up of three components, each of which can be enabled or disabled independently in the Helm values:
+
+- `otmm.coordinator` — the transaction coordinator (XA/LRA/TCC).
+- `otmm.workflowServer` — the [workflow server](#microtx-workflow-server) (see below).
+- `otmm.console` — the web console used to monitor transactions and workflows.
+
+All three are enabled by default. To disable a component, set its `enabled` flag to `false`:
+
+```yaml
+otmm:
+  coordinator:
+    enabled: true
+  workflowServer:
+    enabled: true
+  console:
+    enabled: false
+```
+
+The console exists only to front the coordinator and workflow server, so it is deployed only when at least one of those two components is enabled. If both `otmm.coordinator.enabled` and `otmm.workflowServer.enabled` are `false`, the console is not deployed even if `otmm.console.enabled` is `true`. When deployed, the console is connected only to the backends that are enabled, so a coordinator-only or workflow-only install does not leave the console pointing at a service that was not deployed.
+
 ## MicroTx Workflow Server
 
 The MicroTx Workflow Server extends transaction coordinator with advanced workflow capabilities.

--- a/helm/infra-charts/CHANGELOG.md
+++ b/helm/infra-charts/CHANGELOG.md
@@ -102,6 +102,14 @@ AppVersion: 2.1.0-build.12
 
 - Add Kafka metrics
 
+# 0.0.15 - Jun 5, 2026
+
+AppVersion: 2.1.0-build.13
+
+- Restructure OTMM (MicroTX) values into independently toggleable `coordinator`, `workflowServer`, and `console` components, each with its own image and `pullPolicy`; the top-level `otmm.enabled` flag is removed
+- The OTMM console now deploys only when the coordinator and/or workflow server is enabled; an explicit `otmm.console.enabled: true` is overridden when both are disabled. The console is wired only to the backends that are enabled (no dead coordinator/workflow endpoints in single-backend installs)
+- Fix OTMM templates that still referenced the removed top-level `otmm.image`/`otmm.replicas`/`otmm.metrics` paths
+
 # 0.0.14 - May 20, 2026
 
 AppVersion: 2.1.0-build.13

--- a/helm/infra-charts/obaas/examples/values-default.yaml
+++ b/helm/infra-charts/obaas/examples/values-default.yaml
@@ -35,8 +35,15 @@ ingress-nginx:
 admin-server:
   enabled: true
 
+# OTMM (MicroTX) components can be toggled independently. The console only
+# deploys when the coordinator and/or workflow server is also enabled.
 otmm:
-  enabled: true
+  coordinator:
+    enabled: true
+  workflowServer:
+    enabled: true
+  console:
+    enabled: true
 
 # Database (SIDB-FREE by default)
 # Database uses SIDB-FREE by default from values.yaml

--- a/helm/infra-charts/obaas/examples/values-private-registry.yaml
+++ b/helm/infra-charts/obaas/examples/values-private-registry.yaml
@@ -154,17 +154,32 @@ config-server:
   # Override default resources if needed (defaults: cpu 250m-500m, memory 256Mi-512Mi)
   # resources: {}
 
-# Oracle Transaction Manager for Microservices (OTMM)
+# Oracle Transaction Manager for Microservices (OTMM - MicroTX)
+# Each component (coordinator, workflowServer, console) has its own image and
+# can be toggled independently. The console only deploys when the coordinator
+# and/or workflow server is also enabled.
 otmm:
   global:
     imagePullSecrets: *imagePullSecrets
-  enabled: true
-  replicas: 1
-  image:
-    repository: myregistry.example.com/database/otmm
-    tag: "24.4.1"
-  # Override default resources if needed (defaults: cpu 250m, memory 1Gi)
-  # resources: {}
+  coordinator:
+    enabled: true
+    replicas: 1
+    image:
+      repository: myregistry.example.com/database/microtx-coordinator
+      tag: "26.1.1"
+    # Override default resources if needed (defaults: cpu 250m, memory 1Gi)
+    # resources: {}
+  workflowServer:
+    enabled: true
+    replicas: 1
+    image:
+      repository: myregistry.example.com/database/microtx-workflow
+      tag: "26.1.1"
+  console:
+    enabled: true
+    image:
+      repository: myregistry.example.com/database/microtx-console
+      tag: "26.1.1"
 
 # Oracle Database Exporter (Prometheus metrics for Oracle Database)
 oracle-database-exporter:
@@ -745,7 +760,9 @@ kafka:
 # global kubectl (PVC cleanup hook)  | docker.io                     | global.utilities.kubectl.image.registry
 # eureka                             | container-registry.oracle.com | eureka.image.repository
 # admin-server                       | container-registry.oracle.com | admin-server.image.repository
-# otmm                               | container-registry.oracle.com | otmm.image.repository
+# otmm coordinator                   | container-registry.oracle.com | otmm.coordinator.image.repository
+# otmm workflow server               | container-registry.oracle.com | otmm.workflowServer.image.repository
+# otmm console                       | container-registry.oracle.com | otmm.console.image.repository
 # oracle-database-exporter           | container-registry.oracle.com | oracle-database-exporter.image.repository
 # oracle-database-exporter (busybox) | docker.io                     | oracle-database-exporter.busybox.repository
 # database                           | (varies by type)              | database.image.repository

--- a/helm/infra-charts/obaas/templates/NOTES.txt
+++ b/helm/infra-charts/obaas/templates/NOTES.txt
@@ -13,8 +13,14 @@ Core Services:
 {{- if (index .Values "admin-server").enabled }}
   ✓ Admin Server (Management API) - {{ (index .Values "admin-server").replicas }} replica(s)
 {{- end }}
-{{- if (index .Values "otmm").enabled }}
-  ✓ OTMM (Transaction Manager) - {{ (index .Values "otmm").replicas }} replica(s)
+{{- if .Values.otmm.coordinator.enabled }}
+  ✓ OTMM Coordinator (Transaction Manager) - {{ .Values.otmm.coordinator.replicas }} replica(s)
+{{- end }}
+{{- if .Values.otmm.workflowServer.enabled }}
+  ✓ OTMM Workflow Server - {{ .Values.otmm.workflowServer.replicas }} replica(s)
+{{- end }}
+{{- if eq (include "otmm.console.enabled" .) "true" }}
+  ✓ OTMM Console
 {{- end }}
 
 API Gateway & Ingress:
@@ -70,11 +76,16 @@ Eureka Service Discovery:
 Admin Server:
   Service: {{ .Release.Name }}-admin-server.{{ .Release.Namespace }}.svc.cluster.local:8989
 {{- end }}
-{{- if (index .Values "otmm").enabled }}
+{{- if or .Values.otmm.coordinator.enabled .Values.otmm.workflowServer.enabled }}
 
 Transaction Manager (OTMM):
-  Service: {{ .Release.Name }}-otmm-tcs.{{ .Release.Namespace }}.svc.cluster.local:9000
+{{- if .Values.otmm.coordinator.enabled }}
+  Coordinator: {{ .Release.Name }}-otmm-tcs.{{ .Release.Namespace }}.svc.cluster.local:9000
   Metrics: http://{{ .Release.Name }}-otmm-tcs.{{ .Release.Namespace }}.svc.cluster.local:9000/metrics
+{{- end }}
+{{- if .Values.otmm.workflowServer.enabled }}
+  Workflow Server: {{ .Release.Name }}-otmm-workflow-server.{{ .Release.Namespace }}.svc.cluster.local:9010
+{{- end }}
 {{- end }}
 {{- if (index .Values "apisix").enabled }}
 

--- a/helm/infra-charts/obaas/templates/_helpers.tpl
+++ b/helm/infra-charts/obaas/templates/_helpers.tpl
@@ -554,3 +554,13 @@ For external DBs (ADB-S, OTHER): retrieved from user-provided privAuthN secret
 {{ $serviceValue | b64dec }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+OTMM console effective enablement.
+The console only makes sense when there is a coordinator and/or workflow server
+for it to front, so an explicit console.enabled is overridden to off when both
+coordinator and workflowServer are disabled.
+*/}}
+{{- define "otmm.console.enabled" -}}
+{{- and .Values.otmm.console.enabled (or .Values.otmm.coordinator.enabled .Values.otmm.workflowServer.enabled) -}}
+{{- end -}}

--- a/helm/infra-charts/obaas/templates/otmm/configmap.yaml
+++ b/helm/infra-charts/obaas/templates/otmm/configmap.yaml
@@ -1,6 +1,6 @@
 ## Copyright (c) 2024, 2026, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
-{{- if (index .Values "otmm").enabled }}
+{{- if .Values.otmm.coordinator.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -47,10 +47,10 @@ data:
   STORAGE_TYPE: memory
   TCC_COORDINATOR_ENABLED: "true"
   TMM_APPNAME: {{ .Release.Name }}-otmm-tcs
-  TMM_IMAGE: "{{ (index .Values "otmm").image.repository }}:{{ (index .Values "otmm").image.tag }}"
-  TMM_IMAGE_PULLPOLICY: {{ (index .Values "otmm").image.pullPolicy | default "IfNotPresent" }}
+  TMM_IMAGE: "{{ .Values.otmm.coordinator.image.repository }}:{{ .Values.otmm.coordinator.image.tag }}"
+  TMM_IMAGE_PULLPOLICY: {{ .Values.otmm.coordinator.image.pullPolicy | default "IfNotPresent" }}
   TMM_IMAGE_PULLSECRET: {{ .Values.global.imagePullSecretName }}
-  TMM_REPLICA_COUNT: "{{ (index .Values "otmm").replicas }}"
+  TMM_REPLICA_COUNT: "{{ .Values.otmm.coordinator.replicas }}"
   TRANSACTION_TOKEN_ENABLED: "false"
   XA_COORDINATOR_ENABLED: "true"
   XA_COORDINATOR_TX_MAX_TIMEOUT: "600000"

--- a/helm/infra-charts/obaas/templates/otmm/console.yaml
+++ b/helm/infra-charts/obaas/templates/otmm/console.yaml
@@ -1,7 +1,7 @@
 ## Copyright (c) 2026, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
-{{- if .Values.otmm.console.enabled }}
+{{- if eq (include "otmm.console.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -72,12 +72,12 @@ spec:
         app.kubernetes.io/component: transaction-coordinator
         app.kubernetes.io/part-of: {{ .Release.Name }}
     spec:
-      {{- include "obaas.imagePullSecrets" (dict "local" (index .Values "otmm").imagePullSecrets "global" .Values.global.imagePullSecrets "secretName" .Values.global.imagePullSecretName) | nindent 6 }}
+      {{- include "obaas.imagePullSecrets" (dict "local" .Values.otmm.console.imagePullSecrets "global" .Values.global.imagePullSecrets "secretName" .Values.global.imagePullSecretName) | nindent 6 }}
       serviceAccountName: {{ .Release.Name }}-otmm-console
       containers:
         - name: console
           image: {{ .Values.otmm.console.image.repository }}:{{ .Values.otmm.console.image.tag }}
-          imagePullPolicy: {{ (index .Values "otmm").image.pullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.otmm.console.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - name: http-console
               containerPort: 8080
@@ -104,12 +104,14 @@ spec:
           env:
             - name: CONSOLE_APP_NAME
               value: console
+            {{- if .Values.otmm.coordinator.enabled }}
             - name: TMM_NAMESPACE
               value: {{ .Release.Namespace }}
             - name: TMM_APP_NAME
               value: otmm-tcs
             - name: TMM_TCS_URL
               value: "http://{{ .Release.Name }}-otmm-tcs:9000"
+            {{- end }}
             {{- if eq .Values.otmm.commonConfiguration.security.enabled true }}
             - name: TMM_ADMIN_USER_ROLE_NAMES
               value: {{ .Values.otmm.commonConfiguration.security.identityProvider.adminUserRoles }}
@@ -158,6 +160,7 @@ spec:
             - name: SECURITY_ENABLED
               value: "false"
             {{- end }}
+            {{- if .Values.otmm.workflowServer.enabled }}
             # WorkflowServer URL configuration
             - name: WF_SERVER
               value: "http://{{ .Release.Name }}-otmm-workflow-server:9010"
@@ -168,6 +171,7 @@ spec:
               value: "{{ .Values.otmm.commonConfiguration.externalURL.protocol }}://{{ .Values.otmm.commonConfiguration.externalURL.host }}:{{ .Values.otmm.commonConfiguration.externalURL.port }}"
             {{- else }}
               value: "{{ .Values.otmm.commonConfiguration.externalURL.protocol | default "http" }}://{{ .Values.otmm.commonConfiguration.externalURL.host | default (printf "%s-otmm-console" .Release.Name) }}"
+            {{- end }}
             {{- end }}
             # temporary
             - name: SECURITY_PROPERTIES_COOKIE_ENCRYPTION_ENABLED

--- a/helm/infra-charts/obaas/templates/otmm/service.yaml
+++ b/helm/infra-charts/obaas/templates/otmm/service.yaml
@@ -1,6 +1,6 @@
 ## Copyright (c) 2024, 2026, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
-{{- if (index .Values "otmm").enabled }}
+{{- if .Values.otmm.coordinator.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/infra-charts/obaas/templates/otmm/serviceaccount.yaml
+++ b/helm/infra-charts/obaas/templates/otmm/serviceaccount.yaml
@@ -1,6 +1,6 @@
 ## Copyright (c) 2024, 2026, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
-{{- if (index .Values "otmm").enabled }}
+{{- if .Values.otmm.coordinator.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/infra-charts/obaas/templates/otmm/statefulset.yaml
+++ b/helm/infra-charts/obaas/templates/otmm/statefulset.yaml
@@ -1,7 +1,7 @@
 ## Copyright (c) 2024, 2026, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
-{{- if (index .Values "otmm").enabled }}
-{{- $otmmMetrics := default dict .Values.otmm.metrics }}
+{{- if .Values.otmm.coordinator.enabled }}
+{{- $otmmMetrics := default dict .Values.otmm.coordinator.metrics }}
 {{- $otmmMetricsScrape := default dict $otmmMetrics.scrape }}
 {{- $otmmMetricsEnabled := true }}
 {{- if hasKey $otmmMetrics "enabled" }}
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     {{- include "obaas.labels" . | nindent 4 }}
 spec:
-  replicas: {{ (index .Values "otmm").replicas }}
+  replicas: {{ .Values.otmm.coordinator.replicas }}
   serviceName: {{ .Release.Name }}-otmm-tcs
   selector:
     matchLabels:
@@ -41,14 +41,14 @@ spec:
         signoz.io/path: {{ $otmmMetricsPath | quote }}
       {{- end }}
     spec:
-      {{- include "obaas.imagePullSecrets" (dict "local" (index .Values "otmm").imagePullSecrets "global" .Values.global.imagePullSecrets "secretName" .Values.global.imagePullSecretName) | nindent 6 }}
+      {{- include "obaas.imagePullSecrets" (dict "local" .Values.otmm.coordinator.imagePullSecrets "global" .Values.global.imagePullSecrets "secretName" .Values.global.imagePullSecretName) | nindent 6 }}
       serviceAccountName: {{ .Release.Name }}-otmm-tcs
       securityContext:
         runAsUser: 1000
       containers:
       - name: otmm-tcs
-        image: "{{ (index .Values "otmm").image.repository }}:{{ (index .Values "otmm").image.tag }}"
-        imagePullPolicy: {{ (index .Values "otmm").image.pullPolicy | default "IfNotPresent" }}
+        image: "{{ .Values.otmm.coordinator.image.repository }}:{{ .Values.otmm.coordinator.image.tag }}"
+        imagePullPolicy: {{ .Values.otmm.coordinator.image.pullPolicy | default "IfNotPresent" }}
         ports:
         - name: http
           containerPort: 9000
@@ -62,8 +62,8 @@ spec:
         - name: config-volume
           mountPath: /etc/config
         resources:
-          {{- if (index .Values "otmm").resources }}
-          {{- toYaml (index .Values "otmm").resources | nindent 10 }}
+          {{- if .Values.otmm.coordinator.resources }}
+          {{- toYaml .Values.otmm.coordinator.resources | nindent 10 }}
           {{- else }}
           limits:
             cpu: 1

--- a/helm/infra-charts/obaas/templates/otmm/workflow-server-deployment.yaml
+++ b/helm/infra-charts/obaas/templates/otmm/workflow-server-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         signoz.io/path: {{ $workflowMetricsPath | quote }}
       {{- end }}
     spec:
-      {{- include "obaas.imagePullSecrets" (dict "local" (index .Values "otmm").imagePullSecrets "global" .Values.global.imagePullSecrets "secretName" .Values.global.imagePullSecretName) | nindent 6 }}
+      {{- include "obaas.imagePullSecrets" (dict "local" .Values.otmm.workflowServer.imagePullSecrets "global" .Values.global.imagePullSecrets "secretName" .Values.global.imagePullSecretName) | nindent 6 }}
       serviceAccountName: {{ .Release.Name }}-otmm-workflow-server
       securityContext:
         fsGroup: 1000
@@ -55,7 +55,7 @@ spec:
       containers:
         - name: server
           image: {{ .Values.otmm.workflowServer.image.repository }}:{{ .Values.otmm.workflowServer.image.tag }}
-          imagePullPolicy: {{ (index .Values "otmm").image.pullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.otmm.workflowServer.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: 9010
               name: http

--- a/helm/infra-charts/obaas/templates/otmm/workflow-service.yaml
+++ b/helm/infra-charts/obaas/templates/otmm/workflow-service.yaml
@@ -1,7 +1,7 @@
 ## Copyright (c) 2026, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
-{{- if (index .Values "otmm").enabled }}
+{{- if .Values.otmm.workflowServer.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/infra-charts/obaas/values.yaml
+++ b/helm/infra-charts/obaas/values.yaml
@@ -391,22 +391,25 @@ config-server:
   # Override default resources if needed (defaults: cpu 250m-500m, memory 256Mi-512Mi)
   # resources: {}
 
-# Oracle Transaction Manager for Microservices (OTMM)
+# Oracle Transaction Manager for Microservices (OTMM - MicroTX)
+
 otmm:
-  enabled: true
-  replicas: 1
-  image:
-    repository: container-registry.oracle.com/database/microtx-coordinator
-    tag: "26.1.1"
   commonConfiguration:
     externalURL: {}
     security: {}
-  metrics:
+  coordinator:
     enabled: true
-    scrape:
+    replicas: 1
+    image:
+      repository: container-registry.oracle.com/database/microtx-coordinator
+      tag: "26.1.1"
+      pullPolicy: IfNotPresent
+    metrics:
       enabled: true
-      port: "9000"
-      path: "/metrics"
+      scrape:
+        enabled: true
+        port: "9000"
+        path: "/metrics"
   workflowServer:
     enabled: true
     encryption:
@@ -454,6 +457,7 @@ otmm:
     image:
       repository: container-registry.oracle.com/database/microtx-workflow
       tag: "26.1.1"
+      pullPolicy: IfNotPresent
     replicas: 1
     resources:
       requests:
@@ -467,6 +471,7 @@ otmm:
     image:
       repository: container-registry.oracle.com/database/microtx-console
       tag: "26.1.1"
+      pullPolicy: IfNotPresent
   # Override default resources if needed (defaults: cpu 250m, memory 1Gi)
   # resources: {}
 


### PR DESCRIPTION
MicroTX is now 3 different images. The coordinator, workflow and console. Change so that the end user can choose to install independent components of microtx. The user could choose to install the coordinator and/or workflow.  If coord and/or workflow is enabled, then console can be enabled (default: true) but it will be forced false if neither are enabled.
