### PR TITLE
Enable local Oracle Free Docker setup for SchemaRAG demo

### DIFF
--- a/data-refactoring-advisor/schema-graphrag-demo/.env.example
+++ b/data-refactoring-advisor/schema-graphrag-demo/.env.example
@@ -4,6 +4,7 @@ ADB_USER=schemarag
 ADB_PASSWORD=YourSecurePassword123!
 ADB_WALLET_LOCATION=/path/to/wallet
 ADB_WALLET_PASSWORD=YourWalletDownloadPassword   # set when downloading wallet from OCI console
+ADB_ADMIN_USER=admin
 ADB_ADMIN_PASSWORD=YourAdminPassword123!         # needed for STS cursor-cache load (ADMIN connection)
 
 # Claude API — NL2SQL generation (two-step: Haiku for table retrieval, Opus for SQL generation)

--- a/data-refactoring-advisor/schema-graphrag-demo/README.md
+++ b/data-refactoring-advisor/schema-graphrag-demo/README.md
@@ -142,6 +142,24 @@ cp .env.example .env
 | `ADB_ADMIN_USER` | `admin` (default for ADB) |
 | `ADB_ADMIN_PASSWORD` | Your ADB ADMIN password — used for the STS cursor-cache load step |
 
+For a local Oracle Free Docker container started with:
+
+```bash
+docker run -d -p 1521:1521 -e ORACLE_PASSWORD=Welcome12345 gvenzl/oracle-free:latest-faststart
+```
+
+use:
+
+```env
+ADB_DSN=localhost:1521/FREEPDB1
+ADB_USER=UNIV_SCHEMARAG
+ADB_PASSWORD=Welcome12345
+ADB_WALLET_LOCATION=
+ADB_WALLET_PASSWORD=
+ADB_ADMIN_USER=system
+ADB_ADMIN_PASSWORD=Welcome12345
+```
+
 **LLM configuration**
 
 The pipeline defaults to Claude (Opus for SQL generation, Haiku for table retrieval) but works with any LLM — swap in GPT-4, Gemini, or a local model by updating these variables and the corresponding client code in `src/nl2sql/claude_client_ai.py`.
@@ -167,7 +185,11 @@ The affinity score between two tables is a **Jaccard-based coefficient** compute
 
 ### Database Setup
 
-**Step 1 — Run as ADMIN using SQLcl:**
+Use one of the following setup paths before running the workload pipeline.
+
+**Option A — ADB / SQLcl setup**
+
+Run as ADMIN using SQLcl:
 
 Start SQLcl from your terminal:
 
@@ -193,15 +215,30 @@ DEFINE ADB_PASSWORD=Welcome12345
 
 > Replace `/path/to/Wallet_yourdb.zip` with the full path to your wallet zip file, `yourdb_high` with your ADB service name (found inside the wallet's `tnsnames.ora`), and `Welcome12345` with the value of `ADB_PASSWORD` in your `.env` file.
 
-### Build Pipeline
+After this SQLcl setup, continue with the build pipeline below.
 
-Each step can be run individually or all at once:
+**Option B — Python setup for local Docker or fresh databases**
+
+If you want the Python pipeline to create the schema owner and tables from your `.env` settings, run:
 
 ```bash
-# Full pipeline (all 6 steps)
+python -m src.pipeline.build_pipeline --schema university --step user
+python -m src.pipeline.build_pipeline --schema university --step ddl
+```
+
+The `user` step connects as `ADB_ADMIN_USER` and creates `UNIV_SCHEMARAG` plus the required grants. On local Oracle Free Docker, if `system` cannot grant package privileges directly, the step retries those grants as `SYSDBA` using the same `ADB_ADMIN_PASSWORD`. The `ddl` step connects as `UNIV_SCHEMARAG` and creates the university schema tables. These steps are useful for a brand-new local Oracle Docker container.
+
+### Build Pipeline
+
+After Database Setup, each build step can be run individually or all at once:
+
+```bash
+# Full build pipeline (seed, workload, graph extraction, annotations)
 python -m src.pipeline.build_pipeline --schema university
 
 # Individual steps
+python -m src.pipeline.build_pipeline --schema university --step user       # create schema user + grants
+python -m src.pipeline.build_pipeline --schema university --step ddl        # create schema tables
 python -m src.pipeline.build_pipeline --schema university --step seed
 python -m src.pipeline.build_pipeline --schema university --step sts
 python -m src.pipeline.build_pipeline --schema university --step extract
@@ -378,12 +415,12 @@ python -m src.annotations.annotation_generator --table ENRL_REC
 # Bridge table — verify BRIDGES RegistrarCore:FinancialAid
 python -m src.annotations.annotation_generator --table STU_FA_XREF
 
-# Legacy isolated table — IN_COMMUNITY Legacy and JOINS_WITH LEGACY_CRS_TBL only
-python -m src.annotations.annotation_generator --table OLD_GRADE_ARCH
+# Opaque work table — verify BRIDGES Bursar:RegistrarCore and join paths through ENRL_REC
+python -m src.annotations.annotation_generator --table ACAD_EXCEPTION_WRK
 ```
 
 Expected for ENRL_REC: `IN_COMMUNITY`, `IS_HUB`, `JOINS_WITH` (×4+), affinity levels, `JOINS_PATH` chains.
-Expected for OLD_GRADE_ARCH: `IN_COMMUNITY Legacy` and `JOINS_WITH LEGACY_CRS_TBL` only — no FINANCIAL_AID_APPLICATION, BURS_STUDENT_ACCOUNT, or STU_MST annotations.
+Expected for ACAD_EXCEPTION_WRK: `BRIDGES Bursar:RegistrarCore`, `JOINS_WITH ENRL_REC`, and `JOINS_PATH STU_MST→ENRL_REC→ACAD_EXCEPTION_WRK`.
 
 ### CLI Spot-Checks
 
@@ -394,9 +431,9 @@ python -m src.annotations.annotation_generator --table ENRL_REC
 # Bridge table — should show BRIDGES RegistrarCore:FinancialAid
 python -m src.annotations.annotation_generator --table STU_FA_XREF
 
-# Legacy isolated — should show IN_COMMUNITY Legacy + JOINS_WITH LEGACY_CRS_TBL only
-# Must NOT contain: FINANCIAL_AID_APPLICATION, BURS_STUDENT_ACCOUNT, STU_MST
-python -m src.annotations.annotation_generator --table OLD_GRADE_ARCH
+# Opaque work table — should show BRIDGES Bursar:RegistrarCore
+# Must contain: STU_MST→ENRL_REC→ACAD_EXCEPTION_WRK
+python -m src.annotations.annotation_generator --table ACAD_EXCEPTION_WRK
 
 # Side-by-side NL2SQL comparison
 python -m src.pipeline.query_pipeline \
@@ -1079,4 +1116,26 @@ The following improvements have been identified for future development:
 
 11. **Join column pairs in JOINS_PATH annotations** — The sqlglot AST already contains the ON condition for every JOIN clause (`e.ER_ID = a.AEW_ENRL_KEY`), but the current `join_path_extractor.py` discards it after extracting table names. Capturing and storing these column pairs (with alias resolution) would allow JOINS_PATH annotations to express not just which tables to join but exactly how — e.g. `[ENRL_REC JOINS_PATH STU_MST(STU_ID→ER_STU_ID)→ENRL_REC(ER_ID→AEW_ENRL_KEY)→ACAD_EXCEPTION_WRK]`. This is most valuable for XX_ extension tables where column name mismatches (`SOURCE_CCID` → `CODE_COMBINATION_ID`) are not inferrable from naming conventions alone. Requires changes to `src/graph/join_path_extractor.py`, a `join_conditions CLOB` column added to `UNIV_JOIN_PATHS`, and updated formatting in `src/annotations/annotation_generator.py`.
 
-10. **Oracle Free Docker — full community coverage** — Oracle Free's 2 GB SGA cap (shared pool ~300–400 MB) causes cursor cache eviction during the STS workload step: only ~540 of ~722 statements survive before `LOAD_SQLSET` runs, resulting in 22 annotated tables instead of the full ~55 on ADB. The fix is to increase the shared pool floor (`ALTER SYSTEM SET shared_pool_size = 512M SCOPE=BOTH`) then re-run `--step sts → extract → community → joinpaths → annotate`. Until this is done, Scenario 1 SchemaRAG fails on Docker (Haiku does not see enough annotation context to select `ENRL_REC`), though all other scenarios pass.
+10. **Oracle Free Docker — full community coverage** — Oracle Free's constrained SGA can leave the shared pool too small for this demo workload, causing cursor cache eviction during the STS workload step: only ~540 of ~722 statements may survive before `LOAD_SQLSET` runs, resulting in 22 annotated tables instead of the full ~55 on ADB. The fix is to increase the shared pool floor to the largest value valid for the root container's `sga_target`, then re-run `--step sts → extract → community → joinpaths → annotate`. Connect to the root service as SYSDBA and check the limit:
+
+    ```bash
+    sql sys/<password>@//localhost:1521/FREE as sysdba
+    ```
+
+    ```sql
+    SHOW PARAMETER sga_target
+    SHOW PARAMETER shared_pool_size
+    ```
+
+    Oracle requires `shared_pool_size` to be smaller than 20% of the root container's `sga_target`. For example, with `sga_target=1536M`, `512M` and `384M` are invalid, while this setting is valid and has been observed to raise the actual shared pool from ~104M to ~400M:
+
+    ```sql
+    ALTER SYSTEM SET shared_pool_size = 256M SCOPE=BOTH;
+
+    SELECT pool, ROUND(SUM(bytes)/1024/1024) AS mb
+    FROM v$sgastat
+    WHERE pool = 'shared pool'
+    GROUP BY pool;
+    ```
+
+    Until this is done, Scenario 1 SchemaRAG can fail on Docker because Haiku does not see enough annotation context to select `ENRL_REC`, though all other scenarios may pass.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/components/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/components/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/components/annotation_diff.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/components/annotation_diff.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Before/after annotation text viewer component.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/components/graph_viz.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/components/graph_viz.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Pyvis → Streamlit HTML component helper.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/components/sql_display.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/components/sql_display.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 SQL display helpers — syntax highlighting + missing-table annotation.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/pages/01_Architecture.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/pages/01_Architecture.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Page 1 — Architecture overview with animated pipeline diagram.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/pages/02_Schema_Explorer.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/pages/02_Schema_Explorer.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Page 2 — Browse tables, columns, and FK relationships.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/pages/03_Workload_Graph.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/pages/03_Workload_Graph.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Page 3 — Interactive 7-community graph using Pyvis.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/pages/04_Annotations.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/pages/04_Annotations.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Page 4 — Annotation explorer: side-by-side before/after diff viewer.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/pages/05_NL2SQL_Demo.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/pages/05_NL2SQL_Demo.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Page 5 — THE WOW PAGE: NL → SQL side-by-side comparison.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/pages/06_Comparison.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/pages/06_Comparison.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Page 6 — Quantitative comparison: annotation impact on retrieval quality.

--- a/data-refactoring-advisor/schema-graphrag-demo/app/streamlit_app.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/app/streamlit_app.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 SchemaRAG Demo — Streamlit entry point.

--- a/data-refactoring-advisor/schema-graphrag-demo/sql/university/00_drop_schema.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/sql/university/00_drop_schema.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Drop all university schema objects from UNIV_SCHEMARAG.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/annotations/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/annotations/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/annotations/affinity_classifier.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/annotations/affinity_classifier.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Map numeric affinity scores to the 4 patent-defined levels.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/annotations/annotation_generator.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/annotations/annotation_generator.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Core invention: generate all 4 patent annotation types for a given table.
@@ -331,7 +331,11 @@ if __name__ == "__main__":
     else:
         # Upsert into SCHEMA_EMBEDDINGS (creates row if absent, updates if present)
         from src.annotations.metadata_augmentor import augment_table
-        augment_table(args.table.upper(), ctx)
+        try:
+            augment_table(args.table.upper(), ctx)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise SystemExit(1) from exc
         # Re-generate for display
         lines = generate_annotations(args.table.upper(), ctx)
         if lines:

--- a/data-refactoring-advisor/schema-graphrag-demo/src/annotations/metadata_augmentor.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/annotations/metadata_augmentor.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Combine raw table metadata (columns, FK refs, row count) with
@@ -109,6 +109,17 @@ def _get_community_name(table_name: str, nodes_table: str) -> str:
     return row[0] if row and row[0] else "Unknown"
 
 
+def _table_exists_in_nodes(table_name: str, nodes_table: str) -> bool:
+    """Return True when the workload graph contains this table."""
+    from src.db.connection import get_connection
+    sql = f"SELECT COUNT(*) FROM {nodes_table} WHERE table_name = :tbl"
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, tbl=table_name.upper())
+            (count,) = cur.fetchone()
+    return bool(count)
+
+
 # ---------------------------------------------------------------------------
 # Per-table augmentation
 # ---------------------------------------------------------------------------
@@ -119,6 +130,13 @@ def augment_table(table_name: str, ctx: SchemaContext) -> int:
     annotated and baseline embedding rows.
     Returns the annotation count for the table.
     """
+    table_name = table_name.upper()
+    if not _table_exists_in_nodes(table_name, ctx.nodes_table):
+        raise ValueError(
+            f"Table {table_name} is not present in {ctx.nodes_table}. "
+            "Run --step extract first, or choose a table that appears in the captured workload."
+        )
+
     info = get_table_info(table_name, schema=ctx.schema_name)
     annotation_lines = generate_annotations(table_name, ctx)
     community_name = _get_community_name(table_name, ctx.nodes_table)

--- a/data-refactoring-advisor/schema-graphrag-demo/src/config.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/config.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Centralised configuration — reads from .env via pydantic-settings.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/db/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/db/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/db/connection.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/db/connection.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Oracle ADB connection pool using wallet-based mTLS.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/db/schema_inspector.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/db/schema_inspector.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Reads live schema metadata from ADB data dictionary views.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/db/vector_store.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/db/vector_store.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 CRUD operations on schema embeddings tables.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/embeddings/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/embeddings/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/embeddings/embedding_pipeline.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/embeddings/embedding_pipeline.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Orchestrate embedding of all tables using OCI GenAI via DBMS_VECTOR_CHAIN.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/embeddings/oci_embedder.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/embeddings/oci_embedder.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Embed text via OCI GenAI using DBMS_VECTOR_CHAIN.UTL_TO_EMBEDDING inside ADB.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/graph/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/graph/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/graph/community_detector.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/graph/community_detector.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Run Louvain community detection on the affinity graph and persist results

--- a/data-refactoring-advisor/schema-graphrag-demo/src/graph/community_namer.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/graph/community_namer.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Assign human-readable names to Louvain community IDs.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/graph/graph_builder.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/graph/graph_builder.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Build a NetworkX weighted undirected graph from the schema's EDGES table.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/graph/join_path_extractor.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/graph/join_path_extractor.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Extract multi-hop join-path chains from the SQL Tuning Set.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/claude_client_ai.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/claude_client_ai.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Generate SQL from a natural language question using the Anthropic Claude API.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/query_retriever.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/query_retriever.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Retrieve table annotations from the schema's embeddings table for injection

--- a/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/sql_validator.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/nl2sql/sql_validator.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Basic SQL parse-check before executing Select AI output.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/pipeline/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/pipeline/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/pipeline/build_pipeline.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/pipeline/build_pipeline.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Full build pipeline orchestrator.
@@ -69,6 +69,7 @@ def _run_create_user(ctx: SchemaContext):
     """
     from src.workload.sts_loader import _get_admin_connection
     from src.config import settings
+    import oracledb
 
     schema = ctx.schema_name.upper()
     password = settings.adb_password
@@ -83,6 +84,20 @@ def _run_create_user(ctx: SchemaContext):
         f"GRANT EXECUTE ON dbms_xplan TO {schema}",
         f"GRANT ADMINISTER SQL TUNING SET TO {schema}",
     ]
+
+    def _get_sysdba_connection():
+        kwargs: dict = dict(
+            user="sys",
+            password=settings.adb_admin_password,
+            dsn=settings.adb_dsn,
+            mode=oracledb.AUTH_MODE_SYSDBA,
+        )
+        if settings.adb_wallet_location:
+            kwargs["config_dir"] = str(settings.wallet_path)
+            kwargs["wallet_location"] = str(settings.wallet_path)
+            if settings.adb_wallet_password:
+                kwargs["wallet_password"] = settings.adb_wallet_password
+        return oracledb.connect(**kwargs)
 
     conn = _get_admin_connection()
     try:
@@ -101,23 +116,46 @@ def _run_create_user(ctx: SchemaContext):
             else:
                 console.print(f"[yellow]  User {schema} already exists — skipping CREATE USER[/yellow]")
 
+            failed_grants: list[str] = []
             for grant in grants:
                 try:
                     cur.execute(grant)
                     console.print(f"[dim]  ✓ {grant}[/dim]")
                 except Exception as exc:  # noqa: BLE001
                     console.print(f"[yellow]  SKIP[/yellow] {grant} — {exc!s:.80}")
+                    if "ORA-01031" in str(exc):
+                        failed_grants.append(grant)
 
-            # Enable REST / Database Actions console access for this schema.
-            # ORDS_ADMIN.ENABLE_SCHEMA must run as ADMIN; it is idempotent.
-            cur.callproc("ORDS_ADMIN.ENABLE_SCHEMA", keywordParameters={
-                "p_enabled": True,
-                "p_schema": schema,
-                "p_url_mapping_type": "BASE_PATH",
-                "p_url_mapping_pattern": schema.lower(),
-                "p_auto_rest_auth": True,
-            })
-            console.print(f"[dim]  ✓ ORDS REST access enabled for {schema}[/dim]")
+            if failed_grants:
+                try:
+                    sys_conn = _get_sysdba_connection()
+                    try:
+                        with sys_conn.cursor() as sys_cur:
+                            for grant in failed_grants:
+                                sys_cur.execute(grant)
+                                console.print(f"[dim]  ✓ {grant} (SYSDBA retry)[/dim]")
+                        sys_conn.commit()
+                    finally:
+                        sys_conn.close()
+                except Exception as exc:  # noqa: BLE001
+                    console.print(
+                        "[yellow]  SKIP[/yellow] SYSDBA grant retry — "
+                        f"{exc!s:.100}"
+                    )
+
+            # Enable REST / Database Actions console access when ORDS is available.
+            # Local Oracle Free Docker images commonly do not include ORDS_ADMIN.
+            try:
+                cur.callproc("ORDS_ADMIN.ENABLE_SCHEMA", keywordParameters={
+                    "p_enabled": True,
+                    "p_schema": schema,
+                    "p_url_mapping_type": "BASE_PATH",
+                    "p_url_mapping_pattern": schema.lower(),
+                    "p_auto_rest_auth": True,
+                })
+                console.print(f"[dim]  ✓ ORDS REST access enabled for {schema}[/dim]")
+            except Exception as exc:  # noqa: BLE001
+                console.print(f"[yellow]  SKIP[/yellow] ORDS REST access — {exc!s:.80}")
 
         conn.commit()
     finally:

--- a/data-refactoring-advisor/schema-graphrag-demo/src/pipeline/query_pipeline.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/pipeline/query_pipeline.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Single-call NL→SQL pipeline for the Streamlit app and notebooks.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/schemas/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/schemas/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/schemas/base.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/schemas/base.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 SchemaContext dataclass, SchemaPlugin ABC, and plugin registry.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/schemas/university/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/schemas/university/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/schemas/university/plugin.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/schemas/university/plugin.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """Westfield University schema plugin — fictional 15-year-old university DB with naming chaos."""
 from __future__ import annotations

--- a/data-refactoring-advisor/schema-graphrag-demo/src/schemas/university/seed_data.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/schemas/university/seed_data.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Westfield University — deterministic Faker seeder.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/seed/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/seed/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/workload/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/workload/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/workload/affinity_calculator.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/workload/affinity_calculator.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Affinity calculation between table pairs.

--- a/data-refactoring-advisor/schema-graphrag-demo/src/workload/sts_extractor.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/workload/sts_extractor.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Extract join co-occurrence data from a SQL Tuning Set and persist results

--- a/data-refactoring-advisor/schema-graphrag-demo/src/workload/sts_loader.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/src/workload/sts_loader.py
@@ -1,5 +1,5 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.
 
 """
 Execute the workload queries from a schema's SQL file against ADB,

--- a/data-refactoring-advisor/schema-graphrag-demo/tests/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/tests/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/tests/integration/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/tests/integration/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.

--- a/data-refactoring-advisor/schema-graphrag-demo/tests/unit/__init__.py
+++ b/data-refactoring-advisor/schema-graphrag-demo/tests/unit/__init__.py
@@ -1,2 +1,2 @@
-"""Copyright (c) 2026, Oracle and/or its affiliates.
-Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl."""
+# Copyright (c) 2026, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v1.0 as shown at http://oss.oracle.com/licenses/upl.


### PR DESCRIPTION
Core Demo Fixes
[src/pipeline/build_pipeline.py](/Users/DDRECHSE/projects/microservices-backend/data-refactoring-advisor/schema-graphrag-demo/src/pipeline/build_pipeline.py)
Made --step user work for local Oracle Free Docker.
If system cannot grant DBMS_SQLTUNE / DBMS_XPLAN, it retries failed grants as SYSDBA.
Treats ORDS_ADMIN.ENABLE_SCHEMA as optional, so Docker does not fail when ORDS is absent.

[src/annotations/metadata_augmentor.py](/Users/DDRECHSE/projects/microservices-backend/data-refactoring-advisor/schema-graphrag-demo/src/annotations/metadata_augmentor.py)
Prevents annotation generation from upserting embedding rows for tables not present in UNIV_NODES.

[src/annotations/annotation_generator.py](/Users/DDRECHSE/projects/microservices-backend/data-refactoring-advisor/schema-graphrag-demo/src/annotations/annotation_generator.py)
Turns that missing-table case into a clean CLI error instead of silently creating a zero-annotation row.

Docs / Setup
[README.md](/Users/DDRECHSE/projects/microservices-backend/data-refactoring-advisor/schema-graphrag-demo/README.md)
Added local Oracle Free Docker .env guidance.
Documented --step user and --step ddl.
Added Docker shared-pool tuning guidance using 256M when root sga_target=1536M.
Replaced stale OLD_GRADE_ARCH spot-check with ACAD_EXCEPTION_WRK.

[.env.example](/Users/DDRECHSE/projects/microservices-backend/data-refactoring-advisor/schema-graphrag-demo/.env.example)
Added ADB_ADMIN_USER=admin.

Mechanical Python Cleanup
Many Python files under src/, app/, sql/, and tests/Converted the leading copyright triple-quoted string into comments.
This fixes from __future__ import annotations syntax errors repo-wide.