### PR TITLE
fix(apisix): improve Eureka failover and configure OTEL metadata

### DIFF
--- a/docs-source/site/docs/platform/dboperator.md
+++ b/docs-source/site/docs/platform/dboperator.md
@@ -207,33 +207,7 @@ admin_key=$(
 )
 ```
 
-Configure or verify APISIX OpenTelemetry plugin metadata:
-
-The OBaaS chart enables the APISIX `opentelemetry` plugin and configures the SigNoz collector service. APISIX also requires runtime plugin metadata before route-level traces are emitted. If `plugin_metadata/opentelemetry` is already configured, you can skip this command.
-
-```bash
-curl -i http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry \
-  -H "X-API-KEY: ${admin_key}" \
-  -X PUT \
-  -d '{
-    "trace_id_source": "random",
-    "resource": {
-      "service.name": "APISIX"
-    },
-    "collector": {
-      "address": "http://signoz-otel-collector:4318",
-      "request_timeout": 3
-    },
-    "batch_span_processor": {
-      "drop_on_queue_full": false,
-      "max_queue_size": 1024,
-      "batch_timeout": 2,
-      "inactive_timeout": 1,
-      "max_export_batch_size": 16
-    },
-    "set_ngx_var": false
-  }'
-```
+APISIX OpenTelemetry plugin metadata (`plugin_metadata/opentelemetry`) is registered automatically by a sidecar container in the APISIX pod on every install/upgrade — no manual step is required.
 
 Create the ORDS route:
 

--- a/docs-source/site/docs/platform/eureka.md
+++ b/docs-source/site/docs/platform/eureka.md
@@ -13,6 +13,19 @@ Oracle Backend for Microservices and AI includes the Spring Boot Eureka service 
 
 Spring Boot Eureka Server will be installed if the `eureka.enabled` is set to `true` in the `values.yaml` file. The default namespace for Spring Boot Eureka Server is `eureka`.
 
+### Connection idle timeout
+
+The Eureka server's Jetty connection idle timeout defaults to 90 seconds. This is longer than APISIX/OpenResty's 60-second pooled connection lifetime and prevents APISIX from attempting to reuse a connection that Eureka has already closed.
+
+You can override the timeout in your OBaaS values file:
+
+```yaml
+eureka:
+  connectionIdleTimeout: 90s
+```
+
+Keep this value longer than the APISIX/OpenResty pooled connection lifetime. Lower values can cause intermittent `failed to fetch registry ...: closed` messages while APISIX refreshes the Eureka registry.
+
 ## Access Eureka Web User Interface
 
 To access the Eureka Web User Interface, use kubectl port-forward to create a secure channel to `service/eureka`. Run the following command to establish the secure tunnel (replace the example namespace `obaas-dev` with the namespace where the Spring Boot Eureka Server is deployed):

--- a/helm/infra-charts/CHANGELOG.md
+++ b/helm/infra-charts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Improve APISIX Eureka discovery resilience by configuring direct endpoints for all three Eureka replicas and increasing registry send and read timeouts.
+- Keep Eureka Jetty connections open for 90 seconds by default, longer than APISIX/OpenResty's pooled connection lifetime, to avoid intermittent registry refresh failures caused by stale keepalive connections.
+- Automatically register the required APISIX `opentelemetry` plugin_metadata via a sidecar container in the APISIX pod, eliminating the manual admin-API curl workaround and the recurring "plugin_metadata is required" warning.
+
 ## 0.0.1 - Feb 18, 2026
 
 AppVersion: 2.0.0

--- a/helm/infra-charts/obaas/examples/values-private-registry.yaml
+++ b/helm/infra-charts/obaas/examples/values-private-registry.yaml
@@ -123,6 +123,9 @@ eureka:
     imagePullSecrets: *imagePullSecrets
   enabled: true
   replicas: 3
+  # Keep Jetty server connections alive longer than APISIX/OpenResty's
+  # 60-second pooled connection lifetime to avoid reusing server-closed sockets.
+  connectionIdleTimeout: 90s
   image:
     repository: myregistry.example.com/obaas/service-registry
     tag: "2.1.0"
@@ -466,17 +469,19 @@ apisix:
     discovery:
       enabled: true
       registry:
-        # Eureka service discovery - connects to eureka StatefulSet via alias service
-        # (see templates/eureka/service-alias.yaml)
+        # Eureka service discovery - connects directly to each StatefulSet replica
+        # so APISIX can fail over within the same registry refresh cycle.
         eureka:
           host:
-            - "http://eureka:8761"
+            - "http://{{ .Release.Name }}-eureka-0.{{ .Release.Name }}-eureka.{{ .Release.Namespace }}.svc.cluster.local:8761"
+            - "http://{{ .Release.Name }}-eureka-1.{{ .Release.Name }}-eureka.{{ .Release.Namespace }}.svc.cluster.local:8761"
+            - "http://{{ .Release.Name }}-eureka-2.{{ .Release.Name }}-eureka.{{ .Release.Namespace }}.svc.cluster.local:8761"
           prefix: "/eureka/"
           fetch_interval: 30
           timeout:
             connect: 2000
-            send: 2000
-            read: 5000
+            send: 5000
+            read: 15000
           weight: 100
         # Kubernetes service discovery
         kubernetes: {}

--- a/helm/infra-charts/obaas/templates/eureka/statefulset.yaml
+++ b/helm/infra-charts/obaas/templates/eureka/statefulset.yaml
@@ -56,6 +56,8 @@ spec:
             configMapKeyRef:
               name: {{ .Release.Name }}-eureka-server
               key: url
+        - name: SERVER_JETTY_CONNECTION_IDLE_TIMEOUT
+          value: {{ .Values.eureka.connectionIdleTimeout | quote }}
         {{- if .Values.signoz.enabled }}
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "http://{{ .Release.Name }}-signoz-otel-collector.{{ .Release.Namespace }}:4318"

--- a/helm/infra-charts/obaas/values.yaml
+++ b/helm/infra-charts/obaas/values.yaml
@@ -127,6 +127,9 @@ ai-optimizer:
 eureka:
   enabled: true
   replicas: 3
+  # Keep Jetty server connections alive longer than APISIX/OpenResty's
+  # 60-second pooled connection lifetime to avoid reusing server-closed sockets.
+  connectionIdleTimeout: 90s
   image:
     repository: container-registry.oracle.com/obaas/service-registry
     tag: "2.1.0"
@@ -314,17 +317,19 @@ apisix:
     discovery:
       enabled: true
       registry:
-        # Eureka service discovery - connects to eureka StatefulSet via alias service
-        # (see templates/eureka/service-alias.yaml)
+        # Eureka service discovery - connects directly to each StatefulSet replica
+        # so APISIX can fail over within the same registry refresh cycle.
         eureka:
           host:
-            - "http://eureka:8761"
+            - "http://{{ .Release.Name }}-eureka-0.{{ .Release.Name }}-eureka.{{ .Release.Namespace }}.svc.cluster.local:8761"
+            - "http://{{ .Release.Name }}-eureka-1.{{ .Release.Name }}-eureka.{{ .Release.Namespace }}.svc.cluster.local:8761"
+            - "http://{{ .Release.Name }}-eureka-2.{{ .Release.Name }}-eureka.{{ .Release.Namespace }}.svc.cluster.local:8761"
           prefix: "/eureka/"
           fetch_interval: 30
           timeout:
             connect: 2000
-            send: 2000
-            read: 5000
+            send: 5000
+            read: 15000
           weight: 100
         # Kubernetes service discovery
         kubernetes: {}
@@ -339,6 +344,18 @@ apisix:
         resource:
           service.name: APISIX
         trace_id_source: x-request-id
+        # Consumed by templates/apisix/Job-apisix-plugin-metadata.yaml, which
+        # PUTs this whole opentelemetry block to the Admin API's runtime
+        # plugin_metadata store (a separate mechanism from pluginAttrs above,
+        # which only seeds the static config file). Kept here as the single
+        # source of truth rather than duplicated in a second config block.
+        batch_span_processor:
+          drop_on_queue_full: false
+          max_queue_size: 1024
+          batch_timeout: 2
+          inactive_timeout: 1
+          max_export_batch_size: 16
+        set_ngx_var: false
       prometheus:
         export_uri: /metrics
         metric_prefix: apisix_
@@ -376,6 +393,54 @@ apisix:
   initContainer:
     image: "docker.io/busybox"
     tag: "1.37"
+
+  # Sidecar that registers the opentelemetry plugin's runtime plugin_metadata
+  # via the Admin API. This must run as a sidecar (sharing the pod's network
+  # namespace) rather than a separate Job/pod, because the Admin API's
+  # allow_admin allowlist restricts callers to 127.0.0.1. It reads the
+  # collector/resource/batch_span_processor config back out of the already
+  # rendered config.yaml (plugin_attr.opentelemetry), which is the exact same
+  # values.yaml pluginAttrs.opentelemetry block above, so there is a single
+  # source of truth instead of a duplicated payload here.
+  extraContainers:
+    - name: apisix-plugin-metadata
+      image: "docker.io/alpine/k8s:1.28.13"
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -e
+          until curl -s -o /dev/null http://127.0.0.1:9180/apisix/admin/routes; do
+            echo "Waiting for apisix admin API..."; sleep 5
+          done
+
+          admin_key=$(yq '.deployment.admin.admin_key[] | select(.name == "admin") | .key' /apisix-config/config.yaml)
+          if [ -z "$admin_key" ] || [ "$admin_key" = "null" ]; then
+            echo "ERROR: could not extract APISIX admin_key from mounted config"
+            exit 1
+          fi
+
+          payload=$(yq -o=json '.plugin_attr.opentelemetry' /apisix-config/config.yaml)
+
+          http_status=$(curl -s -o /dev/null -w "%{http_code}" \
+            http://127.0.0.1:9180/apisix/admin/plugin_metadata/opentelemetry \
+            -H "X-API-KEY: ${admin_key}" \
+            -X PUT \
+            -d "$payload")
+
+          unset admin_key
+
+          if [ "$http_status" -ge 200 ] && [ "$http_status" -lt 300 ]; then
+            echo "APISIX opentelemetry plugin_metadata configured successfully (HTTP ${http_status})"
+          else
+            echo "ERROR: failed to set plugin_metadata (HTTP ${http_status})"
+            exit 1
+          fi
+
+          exec sleep infinity
+      volumeMounts:
+        - name: apisix-config
+          mountPath: /apisix-config
+          readOnly: true
 
 # Admin Server
 admin-server:


### PR DESCRIPTION
This PR improves APISIX reliability by enabling failover across all Eureka replicas, preventing stale keepalive connection errors, and registering the required OpenTelemetry runtime plugin metadata. This eliminates intermittent registry refresh failures and repeated OpenTelemetry warnings while restoring reliable trace export.